### PR TITLE
Add GitHub Pages deployment workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,47 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - name: Install dependencies
+        run: npm ci
+      - name: Build site
+        run: npm run build
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: dist
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -18,4 +18,12 @@ npm run build
 npm run preview
 ```
 
-The site is configured with `base: '/bafu.github.io/'` for GitHub Pages deployment.
+## Deployment
+
+GitHub Pages deployment is automated via the **Deploy to GitHub Pages** workflow located in `.github/workflows/deploy.yml`. On every push to `main` (or manual dispatch), the workflow:
+
+1. Installs dependencies with `npm ci`.
+2. Builds the static site with `npm run build`.
+3. Publishes the generated `dist/` directory using the official GitHub Pages actions.
+
+Ensure the repository's **Pages** settings are configured to use **GitHub Actions** as the source so the workflow output is served at https://bafu.github.io/.


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow that builds the Vite site and deploys the dist output to GitHub Pages
- document the Pages automation and required repository setting in the README

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d90724faf48327b7c12aa49967e33c